### PR TITLE
livedisplay: Enable DC Dimming + fingerprint: fix potential issues in enrolling

### DIFF
--- a/hidl/fingerprint/BiometricsFingerprint.cpp
+++ b/hidl/fingerprint/BiometricsFingerprint.cpp
@@ -15,7 +15,7 @@
  */
 
 #define LOG_TAG "android.hardware.biometrics.fingerprint@2.3-service.oplus"
-
+#include <android-base/logging.h>
 #include "BiometricsFingerprint.h"
 
 namespace android {
@@ -44,6 +44,7 @@ Return<uint64_t> BiometricsFingerprint::preEnroll() {
 
 Return<RequestStatus> BiometricsFingerprint::enroll(const hidl_array<uint8_t, 69>& hat,
                                                     uint32_t gid, uint32_t timeoutSec) {
+    setDimlayerHbm(1);                                                   
     return mOplusBiometricsFingerprint->enroll(hat, gid, timeoutSec);
 }
 

--- a/hidl/livedisplay/Android.bp
+++ b/hidl/livedisplay/Android.bp
@@ -38,6 +38,7 @@ cc_binary {
         ":vendor.lineage.livedisplay@2.0-sdm-pa",
         ":vendor.lineage.livedisplay@2.0-sdm-utils",
         ":vendor.lineage.livedisplay@2.1-oplus-se",
+        ":vendor.lineage.livedisplay@2.1-oplus-af",
         "service.cpp",
     ],
     shared_libs: [

--- a/hidl/livedisplay/service.cpp
+++ b/hidl/livedisplay/service.cpp
@@ -20,6 +20,7 @@
 #include <binder/ProcessState.h>
 #include <hidl/HidlTransportSupport.h>
 #include <livedisplay/oplus/SunlightEnhancement.h>
+#include <livedisplay/oplus/AntiFlicker.h>
 #include <livedisplay/sdm/PictureAdjustment.h>
 #include <vendor/lineage/livedisplay/2.1/IPictureAdjustment.h>
 
@@ -34,6 +35,8 @@ using ::vendor::lineage::livedisplay::V2_0::sdm::SDMController;
 using ::vendor::lineage::livedisplay::V2_1::IPictureAdjustment;
 using ::vendor::lineage::livedisplay::V2_1::ISunlightEnhancement;
 using ::vendor::lineage::livedisplay::V2_1::implementation::SunlightEnhancement;
+using ::vendor::lineage::livedisplay::V2_1::IAntiFlicker;
+using ::vendor::lineage::livedisplay::V2_1::implementation::AntiFlicker;
 
 int main() {
     status_t status = OK;
@@ -46,6 +49,7 @@ int main() {
 
     sp<PictureAdjustment> pa = new PictureAdjustment(controller);
     sp<SunlightEnhancement> se = new SunlightEnhancement();
+    sp<AntiFlicker> af = new AntiFlicker();
 
     configureRpcThreadpool(1, true /*callerWillJoin*/);
 
@@ -59,6 +63,12 @@ int main() {
     status = se->registerAsService();
     if (status != OK) {
         LOG(WARNING) << "Could not register service for LiveDisplay HAL SunlightEnhancement Iface ("
+                     << status << ")";
+    }
+
+    status = af->registerAsService();
+    if (status != OK) {
+        LOG(WARNING) << "Could not register service for AntiFlicker HAL SunlightEnhancement Iface ("
                      << status << ")";
     }
 

--- a/hidl/livedisplay/vendor.lineage.livedisplay@2.1-service.oplus.xml
+++ b/hidl/livedisplay/vendor.lineage.livedisplay@2.1-service.oplus.xml
@@ -7,6 +7,10 @@
             <name>ISunlightEnhancement</name>
             <instance>default</instance>
         </interface>
+        <interface>
+            <name>IAntiFlicker</name>
+            <instance>default</instance>
+        </interface>
         <fqname>@2.0::IPictureAdjustment/default</fqname>
     </hal>
 </manifest>


### PR DESCRIPTION
enable DC dimming -- show "Anti-flicker mode in LiveDisplay" 

fingerprint
When the user attempts to enroll a new fingerprint, a strange issue may arise. For instance, immediately after clicking on the button to do so (prior to actually touching the sensor),  onError is invoked; this has the effect to write 0 into `/sys/kernel/oplus_display/dimlayer_hbm`, making impossible for the sensor to work -- brightness in the sensor area is not properly increased.
```
09-30 22:18:04.263  1763  2006 D android.hardware.biometrics.fingerprint@2.1-service: OpticalFingerprint cancel
09-30 22:18:04.287  1763  2006 D android.hardware.biometrics.fingerprint@2.1-service: onError(result:5, error:5)
```

Call setDimlayerHBM(1) in  BiometricsFingerprint::enroll() method results in a properly working enrolling.

EDIT:
as far as DC dimming is concerned, credits go to @luk1337 that fixed this before me. My fault – indeed I did not check whether somebody has been made the same adjustments before me.
ref: https://github.com/LineageOS/android_hardware_oplus/commit/2e125b8e6d17c699b6deac1836de3f1ada4405d8